### PR TITLE
Update blogpost link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-See https://www.meter.com/mac_osx_awdl_psa for more context. This script will disable AWDL (Apple Wireless Direct Link)
+See https://www.meter.com/mac-osx-awdl-psa for more context. This script will disable AWDL (Apple Wireless Direct Link)
 in order to improve WiFi connectivity for Apple M1/M2 MacBooks.
 
 # Usage


### PR DESCRIPTION
The link in the readme pointing to the official meter.com blog post about this issue uses snake case, but the permanent link on our website uses kebab case. Fix that here so that clicking on the link works as expected.