### PR TITLE
Launch Daemon to disable awdl interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-See https://www.meter.com/mac-osx-awdl_psa for more context. This script will disable AWDL (Apple Wireless Direct Link)
+See https://www.meter.com/mac-osx-awdl-psa for more context. This script will disable AWDL (Apple Wireless Direct Link)
 in order to improve WiFi connectivity for Apple M1/M2 MacBooks.
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ in order to improve WiFi connectivity for Apple M1/M2 MacBooks.
 
 1. On your Mac, open the Terminal app.
 2. Run: 
-```sudo bash <(curl -sL https://www.meter.com/awdl-daemon.sh)```
+```bash <(curl -sL https://www.meter.com/awdl-daemon.sh)```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-See https://www.meter.com/mac_osx_awdl_psa for more context. This script will disable AWDL (Apple Wireless Direct Link)
+See https://www.meter.com/mac-osx-awdl_psa for more context. This script will disable AWDL (Apple Wireless Direct Link)
 in order to improve WiFi connectivity for Apple M1/M2 MacBooks.
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
-See https://www.meter.com/mac-osx-awdl-psa for more context. This script will disable AWDL (Apple Wireless Direct Link)
+See https://www.meter.com/mac_osx_awdl_psa for more context. This script will disable AWDL (Apple Wireless Direct Link)
 in order to improve WiFi connectivity for Apple M1/M2 MacBooks.
 
 # Usage
+
+## Run it one time
 
 1. On your Mac, open the Terminal app.
 2. Run: 
 ```bash <(curl -sL https://www.meter.com/awdl.sh)```
 3. Acknowledge the prompt and type in your admin password.
+
+
+## Run it automatically after a restart. 
+
+1. On your Mac, open the Terminal app.
+2. Run: 
+```sudo bash <(curl -sL https://www.meter.com/awdl-daemon.sh)```

--- a/awdl-daemon.sh
+++ b/awdl-daemon.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-curl -s https://raw.githubusercontent.com/meterup/awdl_wifi_scripts/main/disable_awdl.sh > ~/disable_awdl.sh
-sudo chmod u+x ~/disable_awdl.sh
 sudo curl -s https://raw.githubusercontent.com/meterup/awdl_wifi_scripts/main/com.meter.wifi.awdl.plist > /Library/LaunchDaemons/com.meter.wifi.awdl.plist
-sudo sed -i -- "s/YOUR_USERNAME/${USER}/g" /Library/LaunchDaemons/com.meter.wifi.awdl.plist
-rm com.meter.wifi.awdl.plist-- 2> /dev/null
 sudo launchctl unload -w /Library/LaunchDaemons/com.meter.wifi.awdl.plist || true
 sudo launchctl load -w /Library/LaunchDaemons/com.meter.wifi.awdl.plist

--- a/awdl-daemon.sh
+++ b/awdl-daemon.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+curl -s https://raw.githubusercontent.com/meterup/awdl_wifi_scripts/main/disable_awdl.sh > ~/disable_awdl.sh
+sudo chmod u+x ~/disable_awdl.sh
+sudo curl -s https://raw.githubusercontent.com/meterup/awdl_wifi_scripts/main/com.meter.wifi.awdl.plist > /Library/LaunchDaemons/com.meter.wifi.awdl.plist
+sudo sed -i -- "s/YOUR_USERNAME/${USER}/g" /Library/LaunchDaemons/com.meter.wifi.awdl.plist
+rm com.meter.wifi.awdl.plist-- 2> /dev/null
+sudo launchctl unload -w /Library/LaunchDaemons/com.meter.wifi.awdl.plist || true
+sudo launchctl load -w /Library/LaunchDaemons/com.meter.wifi.awdl.plist

--- a/com.meter.wifi.awdl.plist
+++ b/com.meter.wifi.awdl.plist
@@ -6,7 +6,7 @@
 	<string>com.meter.wifi.awdl</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>/Users/abhijeet/disable_awdl.sh</string>
+		<string>/Users/YOUR_USERNAME/disable_awdl.sh</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>

--- a/com.meter.wifi.awdl.plist
+++ b/com.meter.wifi.awdl.plist
@@ -6,9 +6,11 @@
 	<string>com.meter.wifi.awdl</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>/Users/YOUR_USERNAME/disable_awdl.sh</string>
+		<string>ifconfig</string>
+		<string>awdl0</string>
+		<string>down</string>
 	</array>
-	<key>RunAtLoad</key>
-	<true/>
+        <key>StartInterval</key>
+        <integer>2</integer>
 </dict>
 </plist>

--- a/com.meter.wifi.awdl.plist
+++ b/com.meter.wifi.awdl.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.meter.wifi.awdl</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Users/abhijeet/disable_awdl.sh</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
1. Creates a separate script that install a launch Daemon on Mac
2. Offers a script to easier manage install
