### PR TITLE
LaunchDaemon running a script in a loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ in order to improve WiFi connectivity for Apple M1/M2 MacBooks.
 2. Run: 
 ```curl -sL https://www.meter.com/awdl-daemon.sh | bash```
 
-## For MDM scenario or if you want full control
-```
-curl https://github.com/meterup/awdl_wifi_scripts/blob/main/com.meter.wifi.awdl.plist > /Library/LaunchDaemons/com.meter.wifi.awdl.plist; launchctl load -w /Library/LaunchDaemons/com.meter.wifi.awdl.plist
-```
 ## Remove the scripts and renable awdl0 interface
 ```
 curl -s https://raw.githubusercontent.com/meterup/awdl_wifi_scripts/main/cleanup-and-renenable-awdl.sh | bash &> /dev/null

--- a/awdl-daemon.sh
+++ b/awdl-daemon.sh
@@ -4,6 +4,5 @@ curl -s https://raw.githubusercontent.com/meterup/awdl_wifi_scripts/main/disable
 sudo chmod u+x ~/disable_awdl.sh
 cd /Library/LaunchDaemons/ && sudo curl -sO https://raw.githubusercontent.com/meterup/awdl_wifi_scripts/main/com.meter.wifi.awdl.plist
 sudo sed -i -- "s/YOUR_USERNAME/${USER}/g" /Library/LaunchDaemons/com.meter.wifi.awdl.plist
-rm com.meter.wifi.awdl.plist-- 2> /dev/null
 sudo launchctl unload -w /Library/LaunchDaemons/com.meter.wifi.awdl.plist 2> /dev/null
 sudo launchctl load -w /Library/LaunchDaemons/com.meter.wifi.awdl.plist

--- a/awdl-daemon.sh
+++ b/awdl-daemon.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+curl -s https://raw.githubusercontent.com/meterup/awdl_wifi_scripts/main/disable_awdl.sh > ~/disable_awdl.sh
+sudo chmod u+x ~/disable_awdl.sh
 cd /Library/LaunchDaemons/ && sudo curl -sO https://raw.githubusercontent.com/meterup/awdl_wifi_scripts/main/com.meter.wifi.awdl.plist
-sudo launchctl unload -w /Library/LaunchDaemons/com.meter.wifi.awdl.plist > /dev/null 2>&1
+sudo sed -i -- "s/YOUR_USERNAME/${USER}/g" /Library/LaunchDaemons/com.meter.wifi.awdl.plist
+rm com.meter.wifi.awdl.plist-- 2> /dev/null
+sudo launchctl unload -w /Library/LaunchDaemons/com.meter.wifi.awdl.plist 2> /dev/null
 sudo launchctl load -w /Library/LaunchDaemons/com.meter.wifi.awdl.plist

--- a/cleanup-and-renenable-awdl.sh
+++ b/cleanup-and-renenable-awdl.sh
@@ -4,4 +4,5 @@ sudo launchctl unload -w /Library/LaunchDaemons/com.meter.wifi.awdl.plist
 sudo rm /Library/LaunchDaemons/com.meter.wifi.awdl.plist
 sudo pkill -f /tmp/disable_awdl.sh
 sudo rm /tmp/disable_awdl.sh
+rm ~/disable_awdl.sh
 sudo ifconfig awdl0 up

--- a/com.meter.wifi.awdl.plist
+++ b/com.meter.wifi.awdl.plist
@@ -6,11 +6,9 @@
 	<string>com.meter.wifi.awdl</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>ifconfig</string>
-		<string>awdl0</string>
-		<string>down</string>
+		<string>/Users/YOUR_USERNAME/disable_awdl.sh</string>
 	</array>
-        <key>StartInterval</key>
-        <integer>2</integer>
+	<key>RunAtLoad</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
1. LaunchDaemon to outsource to a script that runs in loop
2. This arguably makes it less easy for MDM but should be workable.